### PR TITLE
Fix Notification Dismiss

### DIFF
--- a/ui/src/components/MobileClientListViewItem.js
+++ b/ui/src/components/MobileClientListViewItem.js
@@ -6,6 +6,7 @@ import ComponentSectionLabel from './common/ComponentSectionLabel';
 import MobileClientBuildList from './MobileClientBuildList';
 
 import './OverviewListItemHeader.css';
+import './MobileClientListViewItem.css';
 
 // todo 
 const mobileServices = {

--- a/ui/src/components/MobileClientListViewItem.scss
+++ b/ui/src/components/MobileClientListViewItem.scss
@@ -1,0 +1,3 @@
+.alert-dismissable .close {
+    top: 11px !important;
+}


### PR DESCRIPTION
@sedroche let me know if this is a sufficient fix. `alert-dismissable .close` had `top` set to `1px` this change overrides that class. 

## Screenshot
![update-dismiss](https://user-images.githubusercontent.com/14313111/43387497-7d3adbec-93de-11e8-8b68-b90695c89ff7.png)
