### PR TITLE
 🎨 reuse the existing CRD

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -306,6 +306,12 @@
   revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
 
 [[projects]]
+  name = "github.com/satori/go.uuid"
+  packages = ["."]
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
+
+[[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
@@ -622,6 +628,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "39af8aac3b5766b3ace77a9ff7317247053c2b0b373131a628dbb7ff83888d2e"
+  inputs-digest = "4e9ea47f087096aad1fb93fb20b3cc4221ad565f10c6a0ae8ec4820fd4eb2f58"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -79,3 +79,7 @@ required = [
 [[constraint]]
   name = "gopkg.in/go-playground/validator.v9"
   version = "9.20.2"
+
+[[constraint]]
+  name = "github.com/satori/go.uuid"
+  version = "1.2.0"

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -6,4 +6,5 @@ spec:
   clientType: "android"
   name: "android-app"
   appIdentifier: "test.aerogear.org"
+  apiKey: "bf997a82-9415-40fc-8480-e222a97d55b4"
 

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: mobileclients.aerogear.org
+  name: mobileclients.mobile.k8s.io
 spec:
-  group: aerogear.org
+  group: mobile.k8s.io
   version: v1alpha1
   scope: Namespaced
   names:
@@ -21,6 +21,9 @@ spec:
             clientType:
               type: string
               pattern: 'cordova|iOS|android|xamarin'
+            apiKey:
+              type: string
+              pattern: '(\w{8}-\w{4}-\w{4}-\w{4}-\w{11})'
             name:
               type: string
               pattern: '([\w-])'

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -39,7 +39,7 @@ metadata:
   name: default-account-mobileclient-operator
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: mobile-client-service
 roleRef:
   kind: Role
   name: mobileclient-operator

--- a/mobile-client-service.template.yaml
+++ b/mobile-client-service.template.yaml
@@ -19,6 +19,9 @@ objects:
         labels:
           app: "${SERVICE_NAME}"
       spec:
+        securityContext: {}
+        serviceAccount: "${SERVICE_ACCOUNT_NAME}"
+        serviceAccountName: "${SERVICE_ACCOUNT_NAME}"
         containers:
         - name: "${SERVICE_NAME}"
           image: ${SERVER_IMAGE}
@@ -69,5 +72,9 @@ parameters:
   required: true
 - name: SERVICE_NAME
   description: What to name the service/application in OpenShift. Selectors will be updated also.
+  value: mobile-client-service
+  required: true
+- name: SERVICE_ACCOUNT_NAME
+  description: What to name the service account to run this service
   value: mobile-client-service
   required: true

--- a/pkg/apis/aerogear/v1alpha1/doc.go
+++ b/pkg/apis/aerogear/v1alpha1/doc.go
@@ -1,3 +1,3 @@
 // +k8s:deepcopy-gen=package
-// +groupName=aerogear.org
+// +groupName=mobile.k8s.io
 package v1alpha1

--- a/pkg/apis/aerogear/v1alpha1/register.go
+++ b/pkg/apis/aerogear/v1alpha1/register.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	version   = "v1alpha1"
-	groupName = "aerogear.org"
+	groupName = "mobile.k8s.io"
 )
 
 var (

--- a/pkg/apis/aerogear/v1alpha1/types.go
+++ b/pkg/apis/aerogear/v1alpha1/types.go
@@ -26,6 +26,8 @@ type MobileClientSpec struct {
 	ClientType    string `json:"clientType,required"`
 	Name          string `json:"name,required"`
 	AppIdentifier string `json:appIdentifier,required`
+	ApiKey        string `json:apiKey` //TODO: not sure if this is still required.
+	DmzUrl        string `json:dmzUrl`
 }
 
 //for mobile-services.json

--- a/pkg/mobile/mobileClient.go
+++ b/pkg/mobile/mobileClient.go
@@ -20,7 +20,7 @@ func (r *MobileClientRepoImpl) ReadByName(name string) (*v1alpha1.MobileClient, 
 	c := &v1alpha1.MobileClient{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "MobileClient",
-			APIVersion: "aerogear.org/v1alpha1",
+			APIVersion: "mobile.k8s.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -44,7 +44,7 @@ func (r *MobileClientRepoImpl) List(namespace string) (*v1alpha1.MobileClientLis
 	list := &v1alpha1.MobileClientList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "MobileClient",
-			APIVersion: "aerogear.org/v1alpha1",
+			APIVersion: "mobile.k8s.io/v1alpha1",
 		},
 	}
 	err := sdk.List(r.namespace, list, listOpts)

--- a/pkg/web/mobileClientsHandler.go
+++ b/pkg/web/mobileClientsHandler.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aerogear/mobile-client-service/pkg/mobile"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo"
+	"github.com/satori/go.uuid"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
@@ -34,6 +35,7 @@ type MobileAppCreateRequest struct {
 	Name          string `json:"name" validate:"required"`
 	ClientType    string `json:"clientType" validate:"required,oneof=android iOS cordova xamarin"`
 	AppIdentifier string `json:"appIdentifier"" validate:"required"`
+	DmzUrl        string `json:"dmzUrl"`
 }
 
 type MobileAppUpdateRequest struct {
@@ -44,7 +46,7 @@ func newMobileClientObject(data MobileAppCreateRequest, namespace string) *v1alp
 	return &v1alpha1.MobileClient{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "MobileClient",
-			APIVersion: "aerogear.org/v1alpha1",
+			APIVersion: "mobile.k8s.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      data.Name,
@@ -54,6 +56,8 @@ func newMobileClientObject(data MobileAppCreateRequest, namespace string) *v1alp
 			ClientType:    data.ClientType,
 			Name:          data.Name,
 			AppIdentifier: data.AppIdentifier,
+			ApiKey:        uuid.NewV4().String(),
+			DmzUrl:        data.DmzUrl,
 		},
 	}
 }


### PR DESCRIPTION
Update the CRD to match the one that we currently have in [mobile-core](https://github.com/aerogear/mobile-core/blob/master/installer/roles/create-mobile-client-crd/files/mobile-client-crd.yaml).

This way we don't need to create a separate one.

@sedroche @StephenCoady mind taking a look?