### PR TITLE
Fix for copyToClipboard component styling

### DIFF
--- a/ui/src/components/common/CopyToClipboardMultiline.scss
+++ b/ui/src/components/common/CopyToClipboardMultiline.scss
@@ -7,7 +7,8 @@
   max-height: 350px;
   background-color: #fff;
   word-break: normal;
-  word-wrap: normal
+  word-wrap: normal;
+  margin-top: 0px;
 }
 
 .copy-to-clipboard-multiline .copy-btn {


### PR DESCRIPTION
# Motivation

CopyToClipboard component was not properly styled - copy button was placed outside of the element.